### PR TITLE
Parserator eli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.8
 
 # Add the NodeSource PPA
 # (see: https://github.com/nodesource/distributions/blob/master/README.md)
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash -
 
 # Install any additional OS-level packages you need via apt-get. RUN statements
 # add additional layers to your image, increasing its final size. Keep your

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # DataMade Code Challenge: Parserator
 
+
+#Notes from Eli
+- The setup instructions should be the same I didn't add new dependecies
+- I am currently using windows so I had to change docker-entrypoint.sh and run-tests.sh from clrf→ LF b/c the file wasn't being found 
+- I also changed the nodesource link in the dockerfile to RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - ,  because npm wasnt being installed and the dockerfile script would fail
+
+
+#Things I would change if I had more time
+- Better error handling on the frontend
+- cleaner way to add data to table through js
+- conditional rendering w django instead of css styles
+- more tests 
+
+
+
 Welcome to the DataMade code challenge! 👋
 
 Your task is to recreate the **address parsing form** in DataMade's

--- a/parserator_web/settings.py
+++ b/parserator_web/settings.py
@@ -50,6 +50,31 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'default': {
+                'format': '[DJANGO] %(levelname)s %(asctime)s %(module)s '
+                          '%(name)s.%(funcName)s:%(lineno)s: %(message)s'
+            },
+        },
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+                'formatter': 'default',
+            }
+        },
+        'loggers': {
+            '*': {
+                'handlers': ['console'],
+                'level': 'DEBUG',
+                'propagate': True,
+            }
+        },
+    }
+
 ROOT_URLCONF = 'parserator_web.urls'
 
 TEMPLATES = [

--- a/parserator_web/settings.py
+++ b/parserator_web/settings.py
@@ -74,7 +74,7 @@ LOGGING = {
             }
         },
     }
-
+    
 ROOT_URLCONF = 'parserator_web.urls'
 
 TEMPLATES = [

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,27 +1,75 @@
-/* TODO: Flesh this out to connect the form to the API and render results
-   in the #address-results div. */
-// Grab form 
-const form = document.querySelector(".form");
+// Grab form and needed tags
+form = document.querySelector(".form")
+errorDiv = document.getElementById('error')
+addressDiv = document.getElementById('address-results')
 
-console.log("hi")
 // Send data to addressparse api
 async function sendData() {
 
-  const address = document.querySelector("#address").value
-  console.log(address);
-  const url = `http://localhost:8000/api/parse/?address=${address}`
+  address = document.querySelector("#address").value
+ 
+  url = `http://localhost:8000/api/parse/?address=${address}`
    
   try {
     const response = await fetch(url, {
       method: "GET"
     });
-    console.log(await response.json());
+
+    let data = await response.json()
+
+    if (data.detail) {
+      throw new Error(data.detail)
+    } else {
+      populateTable(data)
+    }
+   
   } catch(err) {
-    console.error(err);
+    displayError(err)
   }
+
+   
 
 }
 
+// Fill table with data from api
+function populateTable(data) {
+ 
+   // Hide error div as a precaution
+
+   errorDiv.style.display= 'none'
+
+   // Unhide address div
+   let addressDiv = document.getElementById('address-results')
+   addressDiv.style = ''
+
+   // Add data to div
+   document.getElementById('parse-type').innerHTML = `${data.address_type}`
+   let tableBody = document.getElementById('address-Table')
+   let htmlToAdd = ``
+  
+   
+   for ( [tag,address] of Object.entries(data.address_components)) {
+
+     htmlToAdd += `<tr>
+                       <td> ${address }</td>
+                       <td> ${tag }</td>
+                    <tr>`
+    
+   }
+
+   tableBody.innerHTML = htmlToAdd
+}
+
+// Hide Table and display error message
+function displayError(err) {
+   
+   addressDiv.style.display= 'none'
+   errorDiv.style = ''
+
+   errorDiv.innerHTML = `${err}`
+}
+
+// Subsribe function to submit button
 form.addEventListener("submit", (event) => {
   event.preventDefault();
   sendData();

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,28 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
+// Grab form 
+const form = document.querySelector(".form");
+
+console.log("hi")
+// Send data to addressparse api
+async function sendData() {
+
+  const address = document.querySelector("#address").value
+  console.log(address);
+  const url = `http://localhost:8000/api/parse/?address=${address}`
+   
+  try {
+    const response = await fetch(url, {
+      method: "GET"
+    });
+    console.log(await response.json());
+  } catch(err) {
+    console.error(err);
+  }
+
+}
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  sendData();
+});

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -29,17 +29,21 @@
               <th>Tag</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody id="address-Table">
           </tbody>
         </table>
       </div>
+      <div id="error" style="display:none">
+      </div>
+      
     </div>
   </div>
 </div>
 {% endblock %}
 
 {% block extra_js %}
-  <script src="{% static 'js/index.js' %}">
+  <script src="{% static 'js/index.js' %}"
+  >
 
     
     

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -5,7 +5,6 @@
 
 {% block body %}
 <div class="container">
-  <h2>TESTTTTT </h2>
   <div class="row pt-5 pb-4">
     <div class="col-12">
       <h3 id="usaddress-parser"><i class="fa fa-fw fa-map-marker-alt"></i> U.S. address parser</h3>

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -5,6 +5,7 @@
 
 {% block body %}
 <div class="container">
+  <h2>TESTTTTT </h2>
   <div class="row pt-5 pb-4">
     <div class="col-12">
       <h3 id="usaddress-parser"><i class="fa fa-fw fa-map-marker-alt"></i> U.S. address parser</h3>
@@ -38,5 +39,9 @@
 {% endblock %}
 
 {% block extra_js %}
-  <script src="{% static 'js/index.js' %}"></script>
+  <script src="{% static 'js/index.js' %}">
+
+    
+    
+  </script>
 {% endblock %}

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -1,10 +1,14 @@
 import usaddress
+import json
+import sys
+import logging
 from django.views.generic import TemplateView
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
 from rest_framework.exceptions import ParseError
 
+logger = logging.getLogger(__name__)
 
 class Home(TemplateView):
     template_name = 'parserator_web/index.html'
@@ -16,9 +20,27 @@ class AddressParse(APIView):
     def get(self, request):
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        return Response({})
+        try:
+            address = request.query_params.get('address', 'default')
+            #logger.debug("TEST")
+            logger.error(address + "here")
+            address_components, address_type = self.parse(address)
+        
+
+            data = {
+                'input_string': address,
+                'adress_components': address_components,
+                'adress_type': address_type
+            }
+
+            return Response(data)       
+        except:
+            raise ParseError(ParseError)
+        
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
+        address_components, address_type = usaddress.tag(address)
+
         return address_components, address_type

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -15,7 +15,7 @@ class AddressParse(APIView):
 
     def get(self, request):
         try:
-            address = request.query_params.get('address', 'default')
+            address = request.query_params.get('address')
             if (len(address) > 0):
                 address_components, address_type = self.parse(address)
 

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -1,14 +1,10 @@
 import usaddress
-import json
-import sys
-import logging
 from django.views.generic import TemplateView
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
 from rest_framework.exceptions import ParseError
 
-logger = logging.getLogger(__name__)
 
 class Home(TemplateView):
     template_name = 'parserator_web/index.html'
@@ -18,29 +14,24 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # TODO: Flesh out this method to parse an address string using the
-        # parse() method and return the parsed components to the frontend.
         try:
             address = request.query_params.get('address', 'default')
-            #logger.debug("TEST")
-            logger.error(address + "here")
-            address_components, address_type = self.parse(address)
-        
+            if (len(address) > 0):
+                address_components, address_type = self.parse(address)
 
-            data = {
-                'input_string': address,
-                'adress_components': address_components,
-                'adress_type': address_type
-            }
+                return Response({
+                    'input_string': address,
+                    'address_components': address_components,
+                    'address_type': address_type
+                })
+            else:
+                raise ValueError()
 
-            return Response(data)       
-        except:
-            raise ParseError(ParseError)
-        
+        except usaddress.RepeatedLabelError:
+            raise ParseError(detail="Address has repeated labels", code=400)
+        except ValueError:
+            raise ParseError(detail="No address provided", code=400)
 
     def parse(self, address):
-        # TODO: Implement this method to return the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
         address_components, address_type = usaddress.tag(address)
-
         return address_components, address_type

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,15 +1,23 @@
-import pytest
 
 
+# This function should return a parsed address
 def test_api_parse_succeeds(client):
-    # TODO: Finish this test. Send a request to the API and confirm that the
-    # data comes back in the appropriate format.
     address_string = '123 main st chicago il'
-    pytest.fail()
+    response = client.get(f"http://localhost:8000/api/parse/?address=${address_string}")
+    assert response.status_code == 200
+    data = response.json()
+    assert {'input_string': '$123 main st chicago il',
+            'address_components':
+            {'AddressNumber': '123', 'StreetName': 'main',
+             'StreetNamePostType': 'st', 'PlaceName': 'chicago',
+             'StateName': 'il'}, 'address_type': 'Street Address'} == data
 
 
+# This function should return a 400 error and
+# return a message saying the given address has repeated labels
 def test_api_parse_raises_error(client):
-    # TODO: Finish this test. The address_string below will raise a
-    # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+    response = client.get(f"http://localhost:8000/api/parse/?address=${address_string}")
+    assert response.status_code == 400
+    data = response.json()
+    assert data['detail'] == "Address has repeated labels"


### PR DESCRIPTION
## Overview

Eli Mauskopf DataMade take home challenge


### Changes
- Completes api/parse endpoint
- Populates frontend table with parsed address 
- adds tests

### Notes


- I am currently using windows so I had to change docker-entrypoint.sh and run-tests.sh from clrf→ LF b/c the file wasn't being found 
- I also changed the nodesource link in the dockerfile to RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - ,  because npm wasnt being installed and the dockerfile script would fail


## Things I would change if I had more time
- Better error handling on the frontend
- cleaner way to add data to table through js
- conditional rendering w django instead of css styles
- more tests 


## Setup Instructions

Once you have Docker and Docker Compose installed, build the application containers:

```
docker-compose build
```

Next, run the app:

```
docker-compose up

###  Test instructions

 docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app